### PR TITLE
honour 'maven.test.skip' system property

### DIFF
--- a/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
 import org.apache.maven.plugins.annotations.Parameter;
@@ -45,6 +46,8 @@ import org.codehaus.plexus.util.Scanner;
 public class AjcTestCompileMojo
     extends AbstractAjcCompiler
 {
+    protected static final String MAVEN_TEST_SKIP = "maven.test.skip";
+
     /**
      * Flag to indicate if the main source dirs should be a part of the compile process.
      * <strong>Note!</strong> This will make all classes in main source dir appear in the
@@ -84,6 +87,17 @@ public class AjcTestCompileMojo
      */
     @Parameter
     private Scanner[] testSources;
+
+    @Override
+    public void execute() throws MojoExecutionException
+    {
+        if (isSkipTestCompile())
+        {
+            getLog().info("Not compiling test sources");
+            return;
+        }
+        super.execute();
+    }
 
     @Override
     protected List<String> getClasspathDirectories()
@@ -126,5 +140,11 @@ public class AjcTestCompileMojo
             additionalPath = project.getBuild().getOutputDirectory();
         }
         return additionalPath;
+    }
+
+    private boolean isSkipTestCompile()
+    {
+        String skipTestCompile = System.getProperty(MAVEN_TEST_SKIP);
+        return Boolean.parseBoolean(skipTestCompile);
     }
 }

--- a/src/test/java/org/codehaus/mojo/aspectj/AjcTestCompileMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/AjcTestCompileMojoTest.java
@@ -1,0 +1,27 @@
+package org.codehaus.mojo.aspectj;
+
+import org.apache.maven.plugin.testing.AbstractMojoTestCase;
+
+public class AjcTestCompileMojoTest extends AbstractMojoTestCase
+{
+
+	public void testExecuteWithSkip() throws Exception {
+		final AjcTestCompileMojo testSubject = new AjcTestCompileMojo();
+		System.setProperty(AjcTestCompileMojo.MAVEN_TEST_SKIP, "true");
+		testSubject.execute();
+	}
+
+	public void testExecuteWithoutSkip() throws Exception {
+		final AjcTestCompileMojo testSubject = new AjcTestCompileMojo();
+
+		try
+		{
+			testSubject.execute();
+		}
+		catch (Exception e)
+		{
+			// should throw exception, as superclass executes
+			// and no setup has been done.
+		}
+	}
+}


### PR DESCRIPTION
Allow the aspectj-maven-plugin to skip aspectj compilation/weaving if the maven.test.skip system property is present.  Currently, if this property is set, test compilation is skipped but AJC still executes on tests.