### PR TITLE
Allow java 9, 10, 11 compliance level

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+This is a fork of the aspectj-maven-plugin that has Java 11 support.
+
 # Mojohaus AspectJ-Maven-Plugin
 
 This plugin  weaves AspectJ aspects into your classes using the AspectJ compiler ("ajc").

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.nickwongdev</groupId>
   <artifactId>aspectj-maven-plugin</artifactId>
-  <version>1.12.1-SNAPSHOT</version>
+  <version>1.12.1</version>
   <packaging>maven-plugin</packaging>
 
   <name>Mojo's AspectJ Maven Plugin - NickWongDev Fork</name>
@@ -42,7 +42,7 @@
     <connection>scm:git:https://github.com/nickwongdev/aspectj-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/nickwongdev/aspectj-maven-plugin.git</developerConnection>
     <url>https://github.com/nickwongdev/aspectj-maven-plugin</url>
-    <tag>HEAD</tag>
+    <tag>aspectj-maven-plugin-1.12.1</tag>
   </scm>
   <distributionManagement>
       <snapshotRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,16 @@
     <url>https://github.com/nickwongdev/aspectj-maven-plugin</url>
     <tag>HEAD</tag>
   </scm>
-
+  <distributionManagement>
+      <snapshotRepository>
+          <id>sonatype-snapshot</id>
+          <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      </snapshotRepository>
+      <repository>
+          <id>sonatype-release</id>
+          <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
+      </repository>
+  </distributionManagement>
   <developers>
     <developer>
       <id>kaare</id>

--- a/pom.xml
+++ b/pom.xml
@@ -8,17 +8,18 @@
     <version>40</version>
   </parent>
 
+  <groupId>com.nickwongdev</groupId>
   <artifactId>aspectj-maven-plugin</artifactId>
-  <version>1.11.1-SNAPSHOT</version>
+  <version>1.12.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
-  <name>Mojo's AspectJ Maven Plugin</name>
+  <name>Mojo's AspectJ Maven Plugin - NickWongDev Fork</name>
   <description>
         Handles AspectJ usage within Maven.
         Functionality provided is: weaving of aspects (or existing aspects from libraries) with the
         test and/or main classes, weaving of pre-existing jars and ajdoc reporting.
   </description>
-  <inceptionYear>2005</inceptionYear>
+  <inceptionYear>2018</inceptionYear>
   <properties>
     <aspectjVersion>1.9.2</aspectjVersion>
     <mavenVersion>3.0.5</mavenVersion>
@@ -34,17 +35,13 @@
 
   <issueManagement>
     <system>GitHub</system>
-    <url>https://github.com/mojohaus/aspectj-maven-plugin/issues/</url>
+    <url>https://github.com/nickwongdev/aspectj-maven-plugin/issues/</url>
   </issueManagement>
-  <ciManagement>
-    <system>Travis-CI</system>
-    <url>https://travis-ci.org/mojohaus/aspectj-maven-plugin</url>
-  </ciManagement>
 
   <scm>
-    <connection>scm:git:https://github.com/mojohaus/aspectj-maven-plugin.git</connection>
-    <developerConnection>scm:git:ssh://git@github.com/mojohaus/aspectj-maven-plugin.git</developerConnection>
-    <url>https://github.com/mojohaus/aspectj-maven-plugin</url>
+    <connection>scm:git:https://github.com/nickwongdev/aspectj-maven-plugin.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/nickwongdev/aspectj-maven-plugin.git</developerConnection>
+    <url>https://github.com/nickwongdev/aspectj-maven-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
@@ -98,6 +95,11 @@
       <name>Krzysztof Debski</name>
       <email>kdebski85@gmail.com</email>
       <timezone>+1</timezone>
+    </contributor>
+    <contributor>
+      <name>Nicholas Wong</name>
+      <email>nickwongdev@gmail.com</email>
+      <timezone>America/LosAngeles</timezone>
     </contributor>
   </contributors>
 

--- a/pom.xml
+++ b/pom.xml
@@ -20,9 +20,9 @@
   </description>
   <inceptionYear>2005</inceptionYear>
   <properties>
-    <aspectjVersion>1.9.1</aspectjVersion>
+    <aspectjVersion>1.9.2</aspectjVersion>
     <mavenVersion>3.0.5</mavenVersion>
-    <doxiaVersion>1.6</doxiaVersion>
+    <doxiaVersion>1.8</doxiaVersion>
     <mojo.java.target>1.8</mojo.java.target> <!-- aspectJ > 1.8.13 is JDK 1.8 minimum -->
     <!-- work around until it is correctly fixed at top parent -->
     <scmpublish.content>${project.build.directory}/staging/aspectj-maven-plugin</scmpublish.content>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.nickwongdev</groupId>
   <artifactId>aspectj-maven-plugin</artifactId>
-  <version>1.12.0</version>
+  <version>1.12.1-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
 
   <name>Mojo's AspectJ Maven Plugin - NickWongDev Fork</name>
@@ -42,7 +42,7 @@
     <connection>scm:git:https://github.com/nickwongdev/aspectj-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/nickwongdev/aspectj-maven-plugin.git</developerConnection>
     <url>https://github.com/nickwongdev/aspectj-maven-plugin</url>
-    <tag>aspectj-maven-plugin-1.12.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>com.nickwongdev</groupId>
   <artifactId>aspectj-maven-plugin</artifactId>
-  <version>1.12.0-SNAPSHOT</version>
+  <version>1.12.0</version>
   <packaging>maven-plugin</packaging>
 
   <name>Mojo's AspectJ Maven Plugin - NickWongDev Fork</name>
@@ -42,7 +42,7 @@
     <connection>scm:git:https://github.com/nickwongdev/aspectj-maven-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/nickwongdev/aspectj-maven-plugin.git</developerConnection>
     <url>https://github.com/nickwongdev/aspectj-maven-plugin</url>
-    <tag>HEAD</tag>
+    <tag>aspectj-maven-plugin-1.12.0</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -193,7 +193,7 @@
         <version>3.5</version>
         <configuration>
           <!-- see: https://github.com/apache/maven-plugin-tools/pull/11 -->
-          <mojoDependencies>org.codehaus.mojo:aspectj-maven-plugin</mojoDependencies>
+          <mojoDependencies>com.nickwongdev:aspectj-maven-plugin</mojoDependencies>
         </configuration>
       </plugin>
       <plugin>
@@ -235,31 +235,6 @@
             <exclude>**/parent-child-test-project/**/*.java</exclude>
             <exclude>**/AbstractAjcMojoTest.java</exclude>
           </excludes>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>install</goal>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <projectsDirectory>src/it</projectsDirectory>
-          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-          <postBuildHookScript>verify</postBuildHookScript>
-          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-          <goals>
-            <goal>clean</goal>
-            <goal>test</goal>
-          </goals>
-          <settingsFile>src/it/settings.xml</settingsFile>
-          <debug>true</debug>
         </configuration>
       </plugin>
 
@@ -307,7 +282,7 @@
         <version>3.5</version>
         <configuration>
           <!-- see: https://github.com/apache/maven-plugin-tools/pull/11 -->
-          <mojoDependencies>org.codehaus.mojo:aspectj-maven-plugin</mojoDependencies>
+          <mojoDependencies>com.nickwongdev:aspectj-maven-plugin</mojoDependencies>
         </configuration>
       </plugin>
       <plugin>
@@ -386,6 +361,43 @@
                   <value>${maven.repo.local}</value>
                 </property>
               </systemProperties>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>integration-test</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>verify</goal>
+                  <goal>run</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <projectsDirectory>src/it</projectsDirectory>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <localRepositoryPath>${project.build.directory}/local-repo
+              </localRepositoryPath>
+              <goals>
+                <goal>clean</goal>
+                <goal>test</goal>
+              </goals>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <debug>true</debug>
             </configuration>
           </plugin>
         </plugins>

--- a/src/it/AjcTestCompilerUsingCorrectClasspath/pom.xml
+++ b/src/it/AjcTestCompilerUsingCorrectClasspath/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>ajctestcompiler-usingcorrectclasspath</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -30,7 +30,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/AnnotationProcessingOutput/pom.xml
+++ b/src/it/AnnotationProcessingOutput/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>annotation-processing-output</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -36,7 +36,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/AnnotationProcessingOutput/verify.groovy
+++ b/src/it/AnnotationProcessingOutput/verify.groovy
@@ -1,2 +1,2 @@
-file = new File(basedir, "target/generated-sources/aspectj-maven-plugin/AutoValue_Clazz.java")
+file = new File(basedir, "target/generated-sources/annotations/AutoValue_Clazz.java")
 assert file.exists()

--- a/src/it/BuildAspectJ7/pom.xml
+++ b/src/it/BuildAspectJ7/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>build-aspectj7</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/BuildConfigFileAndAspectJ5/pom.xml
+++ b/src/it/BuildConfigFileAndAspectJ5/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>buildconfigfile-aspect5</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/BuildConfigFileExclusionsUsingOldStyle/pom.xml
+++ b/src/it/BuildConfigFileExclusionsUsingOldStyle/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>buildexclusions-oldstyle</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/BuildConfigFileUsingOldStyle/pom.xml
+++ b/src/it/BuildConfigFileUsingOldStyle/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>build-oldstyle</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/BuildConfigFileWithUnknownAspectDirectory/pom.xml
+++ b/src/it/BuildConfigFileWithUnknownAspectDirectory/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>build-unknownaspectdir</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/CreateCustomLoadTimeWeaveXml/pom.xml
+++ b/src/it/CreateCustomLoadTimeWeaveXml/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>createcustomloadtimeweavexml</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/CreateDefaultLoadTimeWeaveXml/pom.xml
+++ b/src/it/CreateDefaultLoadTimeWeaveXml/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>createdefaultloadtimeweavexml</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/CreateReport/invoker.properties
+++ b/src/it/CreateReport/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals = clean compile org.codehaus.mojo:aspectj-maven-plugin:${project.version}:aspectj-report
+invoker.goals = clean compile com.nickwongdev:aspectj-maven-plugin:${project.version}:aspectj-report

--- a/src/it/CreateReport/pom.xml
+++ b/src/it/CreateReport/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>ajcreport</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/CreateSite/pom.xml
+++ b/src/it/CreateSite/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>ajcreport</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -29,7 +29,7 @@
         <version>3.3</version>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>
@@ -52,7 +52,7 @@
   <reporting>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <configuration>

--- a/src/it/ExclusionsAntStyle/pom.xml
+++ b/src/it/ExclusionsAntStyle/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>exclusions-antstyle</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/ExclusionsFullClassName/pom.xml
+++ b/src/it/ExclusionsFullClassName/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>exclusions-fullclassname</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/InclusionsAntStyle/pom.xml
+++ b/src/it/InclusionsAntStyle/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>inclusions-antstyle</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/InclusionsFullClassName/pom.xml
+++ b/src/it/InclusionsFullClassName/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>inclusions-fullclassname</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/JavaSourcesDefault/pom.xml
+++ b/src/it/JavaSourcesDefault/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>javasources-default</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/JavaSourcesEmpty/pom.xml
+++ b/src/it/JavaSourcesEmpty/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>javasources-empty</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/JavaSourcesList/pom.xml
+++ b/src/it/JavaSourcesList/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>javasources-list</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/JavaSourcesNoBasedir/pom.xml
+++ b/src/it/JavaSourcesNoBasedir/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>javasources-nobasedir</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/LineNumbersInAjcWarnings/pom.xml
+++ b/src/it/LineNumbersInAjcWarnings/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/MASPECT-99/pom.xml
+++ b/src/it/MASPECT-99/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>MASPECTJ-99</artifactId>
   <version>0.0.1-SNAPSHOT</version>
   <description>Verifies that the absence of code and aspect do not crash the plugin.</description>
@@ -25,7 +25,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/MASPECTJ-110/pom.xml
+++ b/src/it/MASPECTJ-110/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>MASPECTJ-110</artifactId>
   <version>0.0.1-SNAPSHOT</version>
     <description>Verifies that nonexistent directories are not added to compile or testCompile source
@@ -26,7 +26,7 @@
           </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
           <executions>

--- a/src/it/MASPECTJ-86/pom.xml
+++ b/src/it/MASPECTJ-86/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>maspectj-86</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -29,7 +29,7 @@
           </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/MASPECTJ-96/pom.xml
+++ b/src/it/MASPECTJ-96/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>maspectj-96</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -16,7 +16,7 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/NoMainSourceWeave/pom.xml
+++ b/src/it/NoMainSourceWeave/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>no-mainsource-weave</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -30,7 +30,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/NoParameters/pom.xml
+++ b/src/it/NoParameters/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/NoSourcesAvailable/pom.xml
+++ b/src/it/NoSourcesAvailable/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>no-sources-project</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/Parameters/pom.xml
+++ b/src/it/Parameters/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/TOFIX_MASPECTJ-4/pom.xml
+++ b/src/it/TOFIX_MASPECTJ-4/pom.xml
@@ -39,7 +39,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/WrongCompilerVersion/pom.xml
+++ b/src/it/WrongCompilerVersion/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>wrong-compilerversion</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -25,7 +25,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/Xajruntimetarget/pom.xml
+++ b/src/it/Xajruntimetarget/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/XhasMember/pom.xml
+++ b/src/it/XhasMember/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/Xlint/pom.xml
+++ b/src/it/Xlint/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/Xlintfile/pom.xml
+++ b/src/it/Xlintfile/pom.xml
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/XmlConfigured/pom.xml
+++ b/src/it/XmlConfigured/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>XmlConfigured</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/it/Xset/pom.xml
+++ b/src/it/Xset/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mojo.aspectj.it</groupId>
+  <groupId>com.nickwongdev.aspectj.it</groupId>
   <artifactId>xset</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
@@ -24,7 +24,7 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.codehaus.mojo</groupId>
+        <groupId>com.nickwongdev</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
         <version>@project.version@</version>
         <executions>

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -124,7 +124,6 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     * Set the compiler "proc" argument.
     * Aspectj supports Annotation processing since 1.8.2, it can been disabled by <code>proc:none</code>.
     *
-    * @parameter
     * @see <a href="https://www.eclipse.org/aspectj/doc/released/README-182.html">AspectJ 1.8.2 Release notes</a>
     * @see <a href="https://docs.oracle.com/javase/7/docs/technotes/tools/windows/javac.html#processing">Annotation Processing</a>
     */

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcCompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcCompileMojo.java
@@ -38,7 +38,7 @@ import org.codehaus.plexus.util.Scanner;
 /**
  * Weaves all main classes.
  * 
- * @description AspectJ Compiler Plugin.
+ * AspectJ Compiler Plugin.
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
 @Mojo( name="compile", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true )

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -130,7 +130,7 @@ public class AjcHelper
      *
      * @param ajdtBuildDefFile the ajdtBuildDefFile
      * @param basedir the baseDirectory
-     * @return
+     * @return Set of Build Files
      * @throws MojoExecutionException
      */
     public static Set<String> getBuildFilesForAjdtFile( String ajdtBuildDefFile, File basedir )
@@ -165,7 +165,7 @@ public class AjcHelper
      * @param sourceDirs
      * @param includes
      * @param excludes
-     * @return
+     * @return Set of Build Files for Source Dirs
      * @throws MojoExecutionException
      */
     public static Set<String> getBuildFilesForSourceDirs( List<String> sourceDirs, String[] includes, String[] excludes )
@@ -200,7 +200,7 @@ public class AjcHelper
     /**
      * Based on a set of weavedirs returns a set of all the files to be weaved.
      *
-     * @return
+     * @return a set of all the files to be weaved
      * @throws MojoExecutionException
      */
     public static Set<String> getWeaveSourceFiles( String[] weaveDirs )
@@ -258,7 +258,7 @@ public class AjcHelper
      *
      * @param fileName the filename of the argfile
      * @param outputDir the build output area
-     * @return
+     * @return the List of all compiler arguments.
      * @throws IOException
      */
     public static List<String> readBuildConfigFile( String fileName, File outputDir )
@@ -288,7 +288,7 @@ public class AjcHelper
      * Convert a string array to a comma separated list
      *
      * @param strings
-     * @return
+     * @return A comma separated list of Strings
      */
     protected static String getAsCsv( String[] strings )
     {

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -63,7 +63,7 @@ public class AjcHelper
      * List holding all accepted values for the {@code complianceLevel} parameter.
      */
     public static final List<String> ACCEPTED_COMPLIANCE_LEVEL_VALUES =
-            Arrays.asList("1.3", "1.4", "1.5", "1.6", "1.7", "1.8");
+            Arrays.asList("1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11");
 
     /**
      * Checks if the given complianceLevel value is valid.
@@ -103,7 +103,7 @@ public class AjcHelper
               String type = classPathElement.getType();
               if (!type.equals("pom")){
                 cp += classPathElement.getFile().getAbsolutePath();
-                cp += File.pathSeparatorChar;                
+                cp += File.pathSeparatorChar;
               }
             }
         }

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
@@ -49,8 +49,9 @@ import java.util.Set;
 /**
  * Creates an AspectJ HTML report using the {@code ajdoc} tool and format.
  *
+ * A Maven 2.0 ajdoc report
+ *
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
- * @description A Maven 2.0 ajdoc report
  */
 @Mojo( name="aspectj-report", requiresDependencyResolution = ResolutionScope.COMPILE )
 public class AjcReportMojo

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
@@ -39,7 +39,8 @@ import org.codehaus.plexus.util.Scanner;
 /**
  * Weaves all test classes.
  * 
- * @description AspectJ Compiler Plugin.
+ * AspectJ Compiler Plugin.
+ *
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
 @Mojo( name="test-compile", threadSafe = true, defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST )

--- a/src/main/java/org/codehaus/mojo/aspectj/CompilationFailedException.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/CompilationFailedException.java
@@ -6,7 +6,7 @@ import org.aspectj.bridge.IMessage;
 /**
  * Exception thrown when Ajc finds errors during compilation.
  *
- * @author Carlos Sanchez <carlos@apache.org>
+ * @author Carlos Sanchez carlos@apache.org
  */
 public final class CompilationFailedException extends MojoExecutionException {
 

--- a/src/main/java/org/codehaus/mojo/aspectj/EclipseAjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/EclipseAjcMojo.java
@@ -56,7 +56,6 @@ import java.util.Set;
  *
  * @author Juraj Burian
  * @version $Revision$ by $Author$ (at)goal eclipse
- * @description create eclipse configuration of aspectJ
  */
 @Mojo( name="EclipseAjcMojo", requiresDependencyResolution = ResolutionScope.COMPILE )
 public class EclipseAjcMojo

--- a/src/test/projects/aspects-in-main-project/pom.xml
+++ b/src/test/projects/aspects-in-main-project/pom.xml
@@ -26,7 +26,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/test/projects/no-main-weave-project/pom.xml
+++ b/src/test/projects/no-main-weave-project/pom.xml
@@ -26,7 +26,7 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <executions>
                     <execution>

--- a/src/test/projects/no-sources-project/pom.xml
+++ b/src/test/projects/no-sources-project/pom.xml
@@ -20,7 +20,7 @@
 	<build>
 		<plugins>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
+				<groupId>com.nickwongdev</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<executions>
 					<execution>

--- a/src/test/projects/parent-child-test-project/pom.xml
+++ b/src/test/projects/parent-child-test-project/pom.xml
@@ -16,7 +16,7 @@
    <build>
      <plugins>
        <plugin>
-         <groupId>org.codehaus.mojo</groupId>
+         <groupId>com.nickwongdev</groupId>
          <artifactId>aspectj-maven-plugin</artifactId>
          <executions>
            <execution>

--- a/src/test/projects/test-project/pom.xml
+++ b/src/test/projects/test-project/pom.xml
@@ -25,7 +25,7 @@
 	<build>
 		<plugins>
 			<plugin>
-               <groupId>org.codehaus.mojo</groupId>
+               <groupId>com.nickwongdev</groupId>
                <artifactId>aspectj-maven-plugin</artifactId>
                <configuration>
                    <source>1.5</source>
@@ -79,7 +79,7 @@
 				</reportSets>
 			</plugin>
 			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
+				<groupId>com.nickwongdev</groupId>
 				<artifactId>aspectj-maven-plugin</artifactId>
 				<configuration>
 					<verbose>true</verbose>


### PR DESCRIPTION
Maybe I missed something but I wasn't able to compile with ajc using java 9, 10, or 11 as the target level.
The plugin defaults to 1.4 when it doesn't understand the value provided and it only allows up to 1.8.

This simply adds 1.9, 9, 10 and 11 has possible values.