### PR TITLE
use reactor artifacts before dependency or plugin artifacts

### DIFF
--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -92,9 +92,11 @@ public class AjcHelper
         String cp = "";
         Set<Artifact> classPathElements = Collections.synchronizedSet( new LinkedHashSet<>() );
         Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
-        classPathElements.addAll( dependencyArtifacts == null ? Collections.emptySet() : dependencyArtifacts );
+        // Set.addAll only adds if absent, so we want to add the project artifacts first.
         classPathElements.addAll( project.getArtifacts() );
+        classPathElements.addAll( dependencyArtifacts == null ? Collections.emptySet() : dependencyArtifacts );
         classPathElements.addAll( pluginArtifacts == null ? Collections.emptySet() : pluginArtifacts );
+
         for ( Artifact classPathElement  : classPathElements )
         {
             File artifact = classPathElement.getFile();
@@ -103,7 +105,7 @@ public class AjcHelper
               String type = classPathElement.getType();
               if (!type.equals("pom")){
                 cp += classPathElement.getFile().getAbsolutePath();
-                cp += File.pathSeparatorChar;                
+                cp += File.pathSeparatorChar;
               }
             }
         }


### PR DESCRIPTION
Currently if an artifact is both a project artifact (a sibling module) and also a dependency artifact, the latter one will win and make it to the classpath. An artifact from the repository will then be used instead of the current one from the active build.
This will break the build if there were any changes to one module that need to be visible to another module.

The solution is to reorder dependencies when building the class-path such that reactor artifacts are always considered first.

The scenario can happen e.g. in presence of a BOM such as created by cyclonedx-maven-plugin.
