### PR TITLE
Maven Profiles "run-its" and "docs"

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -58,33 +58,7 @@ jobs:
 
       - name: Build with Maven
         shell: bash
-        run: mvn --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its" clean verify
-
-  javadoc:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up cache for ~./m2/repository
-        uses: actions/cache@v2.1.3
-        with:
-          path: |
-            ~/.m2/repository
-            !~/.m2/repository/org/codehaus/mojo/aspectj-maven-plugin
-          key: maven-${{ matrix.os }}-java${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            maven-${{ matrix.os }}-java${{ matrix.java }}-
-            maven-${{ matrix.os }}-
-      - name: Set up JDK
-        uses: actions/setup-java@v2.1.0
-        with:
-          java-version: 8
-          distribution: adopt-openj9
-      - name: Build with Maven
-        shell: bash
-        run: mvn --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its" clean compile javadoc:javadoc
+        run: mvn --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its,docs" clean verify
 
   site:
     needs: build
@@ -110,7 +84,7 @@ jobs:
           distribution: adopt-openj9
       - name: Build with Maven
         shell: bash
-        run: mvn --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its" clean javadoc:javadoc site site:stage
+        run: mvn --show-version --errors --batch-mode clean site site:stage
 
   build-all:
 
@@ -155,6 +129,13 @@ jobs:
           # exclude old maven versions on MacOS.
           - os: macOS-latest
             maven: '3.3.9'
+          # exclude old maven version with various JDKs, one will do.
+          - maven: '3.3.9'
+            java:
+              dist: adopt-hotspot
+          - maven: '3.3.9'
+            java:
+              dist: zulu
 
       fail-fast: false
 
@@ -192,5 +173,5 @@ jobs:
 
       - name: Build with Maven
         shell: bash
-        run: ./mvnw --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its" clean verify
+        run: ./mvnw --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its,docs" clean verify
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![GitHub CI](https://github.com/mojohaus/aspectj-maven-plugin/actions/workflows/maven.yml/badge.svg)](https://github.com/mojohaus/aspectj-maven-plugin/actions/workflows/maven.yml)
+
 # Mojohaus AspectJ-Maven-Plugin
 
 This plugin  weaves AspectJ aspects into your classes using the AspectJ compiler ("ajc").

--- a/pom.xml
+++ b/pom.xml
@@ -244,31 +244,6 @@
           </excludes>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-invoker-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>install</goal>
-              <goal>run</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <projectsDirectory>src/it</projectsDirectory>
-          <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
-          <postBuildHookScript>verify</postBuildHookScript>
-          <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
-          <goals>
-            <goal>clean</goal>
-            <goal>test</goal>
-          </goals>
-          <settingsFile>src/it/settings.xml</settingsFile>
-          <debug>true</debug>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -309,56 +284,83 @@
       defines a property.
     -->
 
-      <profile>
-          <id>tools-jar</id>
-          <activation>
-              <jdk>1.8</jdk> <!-- activate only on JDK8, as 8 is minimum version to run aspectj on-->
-          </activation>
-          <dependencies>
-              <dependency>
-                  <groupId>com.sun</groupId>
-                  <artifactId>tools</artifactId>
-                  <version>1.8</version>
-                  <scope>system</scope>
-                  <systemPath>${java.home}/../lib/tools.jar</systemPath>
-              </dependency>
-          </dependencies>
-      </profile>
-      <profile>
-          <id>java8</id>
-          <activation>
-              <jdk>[1.8,)</jdk>
-          </activation>
-          <properties>
-              <!--
-                Because of this properties section the old way of setting the tools.jar path via a property defined in
-                another profile does not work anymore when importing Maven projects into Eclipse. :-(
-              -->
-              <additionalparam>-Xdoclint:none</additionalparam>
-          </properties>
-      </profile>
     <profile>
-      <id>maven-repo-local</id>
+      <id>tools-jar</id>
       <activation>
-        <property>
-          <name>maven.repo.local</name>
-        </property>
+        <jdk>1.8</jdk> <!-- activate only on JDK8, as 8 is minimum version to run aspectj on-->
       </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.8</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>docs</id>
       <build>
         <plugins>
           <plugin>
-            <artifactId>maven-surefire-plugin</artifactId>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-source-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>default-jar-no-fork</id>
+                <goals>
+                  <goal>jar-no-fork</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-javadoc-plugin</artifactId>
             <configuration>
-              <systemProperties>
-                <property>
-                 <!--
-                    Pass this through to the tests (if set!) to
-                    have them pick the right repository
-                  -->
-                  <name>maven.repo.local</name>
-                  <value>${maven.repo.local}</value>
-                </property>
-              </systemProperties>
+              <failOnError>true</failOnError>
+            </configuration>
+            <executions>
+              <execution>
+                <id>attach-javadocs</id>
+                <goals>
+                  <goal>jar</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>run-its</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>integration-test</id>
+                <goals>
+                  <goal>install</goal>
+                  <goal>integration-test</goal>
+                  <goal>verify</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <projectsDirectory>src/it</projectsDirectory>
+              <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+              <postBuildHookScript>verify</postBuildHookScript>
+              <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+              <goals>
+                <goal>clean</goal>
+                <goal>test</goal>
+              </goals>
+              <settingsFile>src/it/settings.xml</settingsFile>
+              <debug>true</debug>
             </configuration>
           </plugin>
         </plugins>


### PR DESCRIPTION
 - use explicit "docs" and "run-its" profile
 - don't build on old maven versions with as many JDKs