### PR TITLE
Add `javaModules` and `enablePreview` options

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,19 +1,24 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#       http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# MIT License
+# 
+# Copyright 2021 Mojohaus
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
 
 name: GitHub CI
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,13 +1,14 @@
-The MIT License
+MIT License
 
-Copyright 2005-2006 The Codehaus.
+Copyright 2005-2015  Mojo@Codehaus
+Copyright 2015-2021  Mojohaus
 
-Permission is hereby granted, free of charge, to any person obtaining a copy of
-this software and associated documentation files (the "Software"), to deal in
-the Software without restriction, including without limitation the rights to
-use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
-of the Software, and to permit persons to whom the Software is furnished to do
-so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
 The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Mojohaus AspectJ-Maven-Plugin
+# Mojohaus AspectJ Maven Plugin
 
 This is the [aspectj-maven-plugin](https://www.mojohaus.org/aspectj-maven-plugin/).
 
@@ -8,7 +8,7 @@ This is the [aspectj-maven-plugin](https://www.mojohaus.org/aspectj-maven-plugin
 
 ## Overview
 
-This plugin  weaves AspectJ aspects into your classes using the AspectJ compiler ("ajc").
+This plugin weaves AspectJ aspects into your classes using the AspectJ compiler `ajc`.
 Typically, aspects are used in one of two ways within your Maven reactors:
 
   * As part of a Single Project, implying aspects and code are defined within the same Maven project.
@@ -18,7 +18,7 @@ Typically, aspects are used in one of two ways within your Maven reactors:
   * As part of a Multi-module Maven Reactor where one/some project(s) contains aspects and other
     projects within the Maven reactor contain code using the aspects ("woven by the aspects").
     This is a more complex and powerful approach, best suited when several Maven projects should be woven
-    by a common set of aspects. The "Examples: Multi-module AspectJ use" contains a basic walkthrough
+    by a common set of aspects. The "Examples: Multi-module AspectJ use" contains a basic walk-through
     of this approach.
 
 ## Contributing

--- a/src/it/LineNumbersInAjcWarnings/pom.xml
+++ b/src/it/LineNumbersInAjcWarnings/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>WarningMessagesWithLineNumbers</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/NoParameters/pom.xml
+++ b/src/it/NoParameters/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>parameters</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/Parameters/pom.xml
+++ b/src/it/Parameters/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>parameters</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/TOFIX_MASPECTJ-4/pom.xml
+++ b/src/it/TOFIX_MASPECTJ-4/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>maspectj-4</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/Xajruntimetarget/pom.xml
+++ b/src/it/Xajruntimetarget/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>xajruntimetarget</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/XhasMember/pom.xml
+++ b/src/it/XhasMember/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>xhasmember</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/Xlint/pom.xml
+++ b/src/it/Xlint/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>xlint</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/it/Xlintfile/pom.xml
+++ b/src/it/Xlintfile/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.codehaus.mjo.aspectj.it</groupId>
+  <groupId>org.codehaus.mojo.aspectj.it</groupId>
   <artifactId>xlintfile</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -425,8 +425,13 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
   @Parameter
   protected List<String> additionalCompilerArgs = new ArrayList<>();
 
-  /**
-     * Activates compiler preview features (e.g. sealed classes in Java 16) when used with a suitable JDK version
+    /**
+     * Activates compiler preview features (e.g. sealed classes in Java 16) when used with a suitable JDK version.
+     * <p>
+     * <b>Please note:</b> You cannot run code compiled with preview features on any other JDK than the one used for
+     * compilation. For example, records compiled with preview on JDK 15 cannot be used on JDK 16 without recompilation.
+     * This is a JVM limitation unrelated to AspectJ. Also, e.g. sealed classes are preview-1 on JDK 15 and preview-2 on
+     * JDK 16. You still need to recompile, no matter what. 
      *
      * @since 1.13
      */

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -1,8 +1,5 @@
 package org.codehaus.mojo.aspectj;
 
-
-import org.apache.commons.collections.CollectionUtils;
-
 /**
  * The MIT License
  *
@@ -27,6 +24,7 @@ import org.apache.commons.collections.CollectionUtils;
  * SOFTWARE.
  */
 
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.maven.artifact.Artifact;
 import org.apache.maven.artifact.handler.ArtifactHandler;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -405,13 +403,27 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     @Parameter( defaultValue = "false" )
     protected boolean forceAjcCompile;
 
-    /**
-     * Sets the arguments to be passed to the compiler.<br>
-     * Example: &lt;compilerArgs&gt; &lt;arg&gt;-Xmaxerrs=1000&lt;/arg&gt; &lt;arg&gt;-Xlint&lt;/arg&gt; &lt;arg&gt;-J-Duser.language=en_us&lt;/arg&gt;
-     * &lt;/compilerArgs&gt;
-     */
-    @Parameter
-    protected List<String> compilerArgs = new ArrayList<>();
+  /**
+   * Sets additional compiler arguments, e.g.
+   * <pre>{@code
+   * <compilerArgs>
+   *   <arg>-Xmaxerrs=1000</arg>
+   *   <arg>-Xlint</arg>
+   *   <arg>-J-Duser.language=en_us</arg> 
+   * </compilerArgs>
+   * }</pre>
+   * This option can be used in case you want to use AJC options not (yet) supported by this plugin.
+   * <p>
+   * <b>Caveat:</b> Be careful when using this option and select the additional compiler arguments wisely, because
+   * behaviour is undefined if you add arguments which have already been added by the plugin using regular parameters
+   * or their default values. The resulting compiler command line will in that case contain duplicate arguments, which
+   * might be illegal depending on the specific argument. Do not expect to be able to manually override existing
+   * arguments using this option or to replace whole argument lists.
+   *
+   * @since 1.13
+   */
+  @Parameter
+  protected List<String> additionalCompilerArgs = new ArrayList<>();
 
     /**
      * Holder for ajc compiler options
@@ -640,8 +652,8 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
         }
         ajcOptions.addAll(resolvedIncludes);
 
-        if (CollectionUtils.isNotEmpty(compilerArgs)) {
-            ajcOptions.addAll(compilerArgs);
+        if (CollectionUtils.isNotEmpty(additionalCompilerArgs)) {
+            ajcOptions.addAll(additionalCompilerArgs);
         }
     }
 

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -425,6 +425,18 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
   @Parameter
   protected List<String> additionalCompilerArgs = new ArrayList<>();
 
+  /**
+     * Activates compiler preview features (e.g. sealed classes in Java 16) when used with a suitable JDK version
+     *
+     * @since 1.13
+     */
+    // TODO:
+    //   Create tickets for at least Eclipse IDE and IntelliJ IDEA to recognise this switch and import it as a compiler
+    //   and possibly runtime setting. As for AJDT, maybe we have to implement it ourselves, but actually I found no
+    //   references to the Maven module there, so I guess the import is implemented somewhere else.
+    @Parameter( defaultValue = "false" )
+    protected boolean enablePreview;
+
     /**
      * Holder for ajc compiler options
      */
@@ -630,6 +642,10 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
         // Add library artifacts
         addModulesArgument("-aspectpath", ajcOptions, aspectLibraries, getAdditionalAspectPaths(),
                 "an aspect library");
+
+        // Add Java 9+ modules needed for compilation
+        addModulesArgument("--module-path", ajcOptions, javaModules, null,
+                "Java module");
 
         // Add xmlConfigured option and argument
         if (null != xmlConfigured) {
@@ -890,13 +906,23 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     }
 
     public void setTarget(String target) {
-        ajcOptions.add("-target");
-        ajcOptions.add(target);
+        if (AjcHelper.isValidComplianceLevel(target)) {
+            ajcOptions.add("-target");
+            ajcOptions.add(target);
+        }
     }
 
     public void setSource(String source) {
-        ajcOptions.add("-source");
-        ajcOptions.add(source);
+        if (AjcHelper.isValidComplianceLevel(source)) {
+            ajcOptions.add("-source");
+            ajcOptions.add(source);
+        }
+    }
+
+    public void setEnablePreview(boolean enablePreview) {
+        if (enablePreview) {
+            ajcOptions.add("--enable-preview");
+        }
     }
 
     public void setVerbose(boolean verbose) {

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -48,8 +48,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * <div>Base class for the two aspectJ compiletime weaving mojos.</div>
- * <div>For all available options see <a href="http://www.eclipse.org/aspectj/doc/released/devguide/ajc-ref.html">ajc-ref</a></div>
+ * Base class for the two aspectJ compile-time weaving mojos.
+ * <p>
+ * For all available options see <a href="http://www.eclipse.org/aspectj/doc/released/devguide/ajc-ref.html">ajc-ref</a>
  *
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
@@ -191,25 +192,25 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     protected boolean XhasMember;
 
     /**
-     * Specify classfile target setting (1.1 to 1.8) default is 1.2
+     * Specify bytecode target setting (1.3 to 1.9, 10 to 16). See 'complianceLevel' for details. 
      *
+     * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
     @Parameter( defaultValue = "${project.build.java.target}" )
     protected String target;
 
     /**
-     * Toggle assertions (1.3, 1.4, 1.5, 1.6, 1.7 or 1.8 - default is 1.4). When using -source 1.3, an assert()
-     * statement valid under Java 1.4 will result in a compiler error. When using -source 1.4, treat assert
-     * as a keyword and implement assertions according to the 1.4 language spec. When using -source 1.5 or higher, Java
-     * 5 language features are permitted. With --source 1.7 or higher Java 7 features are supported.
+     * Specify source code language level (1.3 to 1.9, 10 to 16). See 'complianceLevel' for details. 
      *
+     * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
     @Parameter( defaultValue = "${mojo.java.target}" )
     protected String source;
 
     /**
-     * Specify compiler compliance setting.
-     * Defaults to 1.4, with permitted values ("1.3", "1.4", "1.5", "1.6" and "1.7", "1.8").
+     * Specify compiler compliance setting (same as setting 'source' and 'target' to the same level).
+     * Permitted values: 1.3, 1.4, 1.5, 5, 5.0, 1.6, 6, 6.0, 1.7, 7, 7.0, 1.8, 8, 8.0,
+     * 1.9, 9, 9.0, 10, 10.0, 11, 11.0, 12, 12.0, 13, 13.0, 14, 14.0, 15, 15.0, 16, 16.0.
      *
      * @see org.codehaus.mojo.aspectj.AjcHelper#ACCEPTED_COMPLIANCE_LEVEL_VALUES
      */
@@ -354,22 +355,22 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
      * Supported values are shown in the list below, with their respective explanations - as copied
      * directly from the AJC reference.
      * <dl>
-     * <dt>constructorName</dt>
-     * <dd>method with constructor name</dd>
-     * <dt>packageDefaultMethod</dt>
-     * <dd>attempt to override package-default method</dd>
-     * <dt>deprecation</dt>
-     * <dd>usage of deprecated type or member</dd>
-     * <dt>maskedCatchBlocks</dt>
-     * <dd>hidden catch block</dd>
-     * <dt>unusedLocals</dt>
-     * <dd>local variable never read</dd>
-     * <dt>unusedArguments</dt>
-     * <dd>method argument never read</dd>
-     * <dt>unusedImports</dt>
-     * <dd>import statement not used by code in file</dd>
-     * <dt>none</dt>
-     * <dd>suppress all compiler warnings</dd>
+     *   <dt>constructorName</dt>
+     *   <dd>method with constructor name</dd>
+     *   <dt>packageDefaultMethod</dt>
+     *   <dd>attempt to override package-default method</dd>
+     *   <dt>deprecation</dt>
+     *   <dd>usage of deprecated type or member</dd>
+     *   <dt>maskedCatchBlocks</dt>
+     *   <dd>hidden catch block</dd>
+     *   <dt>unusedLocals</dt>
+     *   <dd>local variable never read</dd>
+     *   <dt>unusedArguments</dt>
+     *   <dd>method argument never read</dd>
+     *   <dt>unusedImports</dt>
+     *   <dd>import statement not used by code in file</dd>
+     *   <dt>none</dt>
+     *   <dd>suppress all compiler warnings</dd>
      * </dl>
      *
      * @see <a href="http://www.eclipse.org/aspectj/doc/released/devguide/ajc-ref.html#ajc">Eclipse AJC reference</a>
@@ -378,26 +379,21 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     protected String warn;
 
     /**
-     * <div>
      * The filename holding AJC build arguments.
      * The file will be placed in the project build output directory, and will contain all the arguments passed to
      * the AJC compiler in the last run, and also all the files included in the AJC build.
-     * </div>
-     * <div>
+     * <p>
      * Sample content shown below to illustrate typical content within the builddef.lst file:
-     * <pre>
-     *     <code>
+     * <pre><code>
      * -1.6
      * -encoding
      * UTF-8
      * -classpath
-     * /Users/lj/Development/Projects/Nazgul/nazgul_tools/validation/validation-api/target/nazgul-tools-validation-api-2.0.10-SNAPSHOT.jar:/Users/lj/.m2/repository/org/slf4j/slf4j-api/1.7.5/slf4j-api-1.7.5.jar:/Users/lj/.m2/repository/org/aspectj/aspectjrt/1.7.3/aspectjrt-1.7.3.jar:/Users/lj/.m2/repository/junit/junit/4.11/junit-4.11.jar:/Users/lj/.m2/repository/ch/qos/logback/logback-classic/1.0.13/logback-classic-1.0.13.jar:/Users/lj/.m2/repository/org/apache/commons/commons-lang3/3.1/commons-lang3-3.1.jar:/Users/lj/Development/Projects/Nazgul/nazgul_tools/validation/validation-aspect/target/classes
+     * /my/library/lib.jar:/somewhere/aspectjrt.jar:/my/project/target/classes
      * -d
-     * /Users/lj/Development/Projects/Nazgul/nazgul_tools/validation/validation-aspect/target/classes
-     * /Users/lj/Development/Projects/Nazgul/nazgul_tools/validation/validation-aspect/src/main/java/se/jguru/nazgul/tools/validation/aspect/ValidationAspect.java
-     *     </code>
-     * </pre>
-     * </div>
+     * /my/project/target/classes
+     * /my/project/src/main/java/org/acme/ValidationAspect.java
+     * </code></pre>
      */
     @Parameter( defaultValue = "builddef.lst" )
     protected String argumentFileName = "builddef.lst";
@@ -472,7 +468,7 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
     /**
      * Do the AspectJ compiling.
      *
-     * @throws MojoExecutionException
+     * @throws MojoExecutionException if arguments file cannot be written
      */
     @SuppressWarnings("unchecked")
     public void execute() throws MojoExecutionException {
@@ -731,7 +727,7 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
      * Checks modifications that would make us need a build
      *
      * @return <code>true</code> if build is needed, otherwise <code>false</code>
-     * @throws MojoExecutionException
+     * @throws MojoExecutionException if an unexpected error occurs, e.g. weave directories cannot be resolved 
      */
     protected boolean isBuildNeeded()
             throws MojoExecutionException {

--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcMojo.java
@@ -70,6 +70,15 @@ public abstract class AbstractAjcMojo extends AbstractMojo
     protected String[] weaveDirectories;
 
     /**
+     * Java 9+ modules to build the module path from.
+     * Corresponds to <code>ajc --module-path</code> option.
+     *
+     * @since 1.13
+     */
+    @Parameter
+    protected Module[] javaModules;
+
+    /**
      * Weave binary aspects from the jars.
      * The aspects should have been output by the same version of the compiler.
      * The modules must also be dependencies of the project.

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcCompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcCompileMojo.java
@@ -36,7 +36,9 @@ import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.Scanner;
 
 /**
- * Weaves all main classes.AspectJ Compiler Plugin.
+ * Weaves all main classes.
+ * 
+ * AspectJ Compiler Plugin.
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
 @Mojo( name="compile", defaultPhase = LifecyclePhase.COMPILE, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true )

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -90,9 +90,12 @@ public class AjcHelper
     public static String createClassPath( MavenProject project, List<Artifact> pluginArtifacts, List<String> outDirs )
     {
         String cp = "";
-        Set<Artifact> classPathElements = Collections.synchronizedSet( new LinkedHashSet<>() );
+        Set<Artifact> classPathElements = Collections.synchronizedSet(
+            // LinkedHashSet preserves order by insertion for iteration
+            new LinkedHashSet<>()
+        );
         Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
-        // Set.addAll only adds if absent, so we want to add the project artifacts first.
+        // Set.addAll only adds if absent, so we want to add the project artifacts first
         classPathElements.addAll( project.getArtifacts() );
         classPathElements.addAll( dependencyArtifacts == null ? Collections.emptySet() : dependencyArtifacts );
         classPathElements.addAll( pluginArtifacts == null ? Collections.emptySet() : pluginArtifacts );

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -128,12 +128,12 @@ public class AjcHelper
     /**
      * Based on a AJDT build properties file resolves the combination of all
      * include and exclude statements and returns a set of all the files to be
-     * compiled and weaved.
+     * compiled and woven.
      *
      * @param ajdtBuildDefFile the ajdtBuildDefFile
      * @param basedir the baseDirectory
-     * @return
-     * @throws MojoExecutionException
+     * @return Set of Build Files
+     * @throws MojoExecutionException if build properties are not found or cannot be read
      */
     public static Set<String> getBuildFilesForAjdtFile( String ajdtBuildDefFile, File basedir )
         throws MojoExecutionException
@@ -162,13 +162,13 @@ public class AjcHelper
 
     /**
      * Based on a set of sourcedirs, apply include and exclude statements and
-     * returns a set of all the files to be compiled and weaved.
+     * returns a set of all the files to be compiled and woven.
      *
-     * @param sourceDirs
-     * @param includes
-     * @param excludes
-     * @return
-     * @throws MojoExecutionException
+     * @param sourceDirs source directories
+     * @param includes file include patterns
+     * @param excludes file exclude patterns
+     * @return Set of Build Files for Source Dirs
+     * @throws MojoExecutionException if sourceDirs cannot be resolved
      */
     public static Set<String> getBuildFilesForSourceDirs( List<String> sourceDirs, String[] includes, String[] excludes )
         throws MojoExecutionException
@@ -200,10 +200,11 @@ public class AjcHelper
     }
 
     /**
-     * Based on a set of weavedirs returns a set of all the files to be weaved.
+     * Based on a set of weave directories returns a set of all the files to be woven.
      *
-     * @return
-     * @throws MojoExecutionException
+     * @param weaveDirs weave directories
+     * @return a set of all the files to be woven
+     * @throws MojoExecutionException if weave directories cannot be resolved
      */
     public static Set<String> getWeaveSourceFiles( String[] weaveDirs )
         throws MojoExecutionException
@@ -236,7 +237,7 @@ public class AjcHelper
      * @param arguments All arguments passed to ajc in this run
      * @param fileName the filename of the argfile
      * @param outputDir the build output area.
-     * @throws IOException
+     * @throws IOException if argfile cannot be created or written
      */
     public static void writeBuildConfigToFile( List<String> arguments, String fileName, File outputDir )
         throws IOException
@@ -260,8 +261,8 @@ public class AjcHelper
      *
      * @param fileName the filename of the argfile
      * @param outputDir the build output area
-     * @return
-     * @throws IOException
+     * @return the List of all compiler arguments.
+     * @throws IOException if any file operation fails
      */
     public static List<String> readBuildConfigFile( String fileName, File outputDir )
         throws IOException
@@ -289,8 +290,8 @@ public class AjcHelper
     /**
      * Convert a string array to a comma separated list
      *
-     * @param strings
-     * @return
+     * @param strings string array to be converted
+     * @return A comma separated list of Strings
      */
     protected static String getAsCsv( String[] strings )
     {
@@ -311,7 +312,7 @@ public class AjcHelper
 
     /**
      * Helper method to find all .java or .aj files specified by the
-     * includeString. The includeString is a comma separated list over files, or
+     * inExcludeString. The includeString is a comma separated list over files, or
      * directories relative to the specified basedir. Examples of correct
      * listings
      *
@@ -323,22 +324,22 @@ public class AjcHelper
      *         src/main/java/com/project/AnAspect.java
      * </pre>
      *
-     * @param input
+     * @param inExcludeString in-/exclude string
      * @param basedir the baseDirectory
-     * @return a list over all files inn the include string
-     * @throws MojoExecutionException
+     * @return a list over all files in the include string
+     * @throws MojoExecutionException if Java or AspectJ source files cannot be resolved
      */
-    protected static Set<String> resolveIncludeExcludeString( String input, File basedir )
+    protected static Set<String> resolveIncludeExcludeString( String inExcludeString, File basedir )
         throws MojoExecutionException
     {
         Set<String> inclExlSet = new LinkedHashSet<>();
         try
         {
-            if ( null == input || input.trim().equals( "" ) )
+            if ( null == inExcludeString || inExcludeString.trim().equals( "" ) )
             {
                 return inclExlSet;
             }
-            String[] elements = input.split( "," );
+            String[] elements = inExcludeString.split( "," );
             if ( null != elements )
             {
 

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -92,7 +92,7 @@ public class AjcHelper
         String cp = "";
         Set<Artifact> classPathElements = Collections.synchronizedSet(
             // LinkedHashSet preserves order by insertion for iteration
-            new LinkedHashSet<>()
+          new LinkedHashSet<>()
         );
         Set<Artifact> dependencyArtifacts = project.getDependencyArtifacts();
         // Set.addAll only adds if absent, so we want to add the project artifacts first
@@ -141,7 +141,7 @@ public class AjcHelper
     public static Set<String> getBuildFilesForAjdtFile( String ajdtBuildDefFile, File basedir )
         throws MojoExecutionException
     {
-        Set<String> result = new LinkedHashSet<String>();
+        Set<String> result = new LinkedHashSet<>();
 
         Properties ajdtBuildProperties = new Properties();
         try
@@ -176,7 +176,7 @@ public class AjcHelper
     public static Set<String> getBuildFilesForSourceDirs( List<String> sourceDirs, String[] includes, String[] excludes )
         throws MojoExecutionException
     {
-        Set<String> result = new LinkedHashSet<String>();
+        Set<String> result = new LinkedHashSet<>();
 
         for ( String sourceDir : sourceDirs )
         {
@@ -225,7 +225,7 @@ public class AjcHelper
                 }
                 catch ( IOException e )
                 {
-                    throw new MojoExecutionException( "IO Error resolving weavedirs", e );
+                    throw new MojoExecutionException( "IO Error resolving weave directories", e );
                 }
             }
         }
@@ -270,7 +270,7 @@ public class AjcHelper
     public static List<String> readBuildConfigFile( String fileName, File outputDir )
         throws IOException
     {
-        List<String> arguments = new ArrayList<String>();
+        List<String> arguments = new ArrayList<>();
         File argFile = new File( outputDir, fileName );
         if ( FileUtils.fileExists( argFile.getAbsolutePath() ) )
         {

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcHelper.java
@@ -62,8 +62,23 @@ public class AjcHelper
     /**
      * List holding all accepted values for the {@code complianceLevel} parameter.
      */
-    public static final List<String> ACCEPTED_COMPLIANCE_LEVEL_VALUES =
-            Arrays.asList("1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "9", "10", "11", "12", "13", "14", "15", "16");
+    public static final List<String> ACCEPTED_COMPLIANCE_LEVEL_VALUES = Arrays.asList(
+      // TODO: update from AJC (AspectJ Compiler) regularly, which in turn extends ECJ (Eclipse Java Compiler)
+      "1.3",
+      "1.4",
+      "1.5", "5", "5.0",
+      "1.6", "6", "6.0",
+      "1.7", "7", "7.0",
+      "1.8", "8", "8.0",
+      "1.9", "9", "9.0",
+      "10", "10.0",
+      "11", "11.0",
+      "12", "12.0",
+      "13", "13.0",
+      "14", "14.0",
+      "15", "15.0",
+      "16", "16.0"
+    );
 
     /**
      * Checks if the given complianceLevel value is valid.

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcReportMojo.java
@@ -48,7 +48,9 @@ import java.util.Set;
 
 /**
  * Creates an AspectJ HTML report using the {@code ajdoc} tool and format.
+ *
  * A Maven 2.0 ajdoc report
+ *
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
 @Mojo( name="aspectj-report", requiresDependencyResolution = ResolutionScope.COMPILE )
@@ -280,7 +282,7 @@ public class AjcReportMojo
     }
 
     /**
-     * Get the directories containg sources
+     * @return list of source directories
      */
     @SuppressWarnings( "unchecked" )
     protected List<String> getSourceDirectories()
@@ -300,7 +302,7 @@ public class AjcReportMojo
     }
 
     /**
-     * get compileroutput directory.
+     * @return list of classpath directories
      */
     protected List<String> getClasspathDirectories()
     {
@@ -419,7 +421,9 @@ public class AjcReportMojo
     }
 
     /**
-     * Setters which when called sets compiler arguments
+     * Set source compliance level
+     * 
+     * @param complianceLevel compliance level
      */
     public void setComplianceLevel( String complianceLevel )
     {

--- a/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AjcTestCompileMojo.java
@@ -37,7 +37,10 @@ import org.codehaus.plexus.util.DirectoryScanner;
 import org.codehaus.plexus.util.Scanner;
 
 /**
- * Weaves all test classes. AspectJ Compiler Plugin.
+ * Weaves all test classes.
+ * 
+ * AspectJ Compiler Plugin.
+ *
  * @author <a href="mailto:kaare.nilsen@gmail.com">Kaare Nilsen</a>
  */
 @Mojo( name="test-compile", threadSafe = true, defaultPhase = LifecyclePhase.TEST_COMPILE, requiresDependencyResolution = ResolutionScope.TEST )

--- a/src/main/java/org/codehaus/mojo/aspectj/MavenMessageHandler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/MavenMessageHandler.java
@@ -100,6 +100,7 @@ public class MavenMessageHandler extends MessageHandler {
      * Copies output from the supplied message onto the active Maven Log.
      * If the message type (i.e. {@code message.getKind()}) is listed in the showDetailsForMessageKindList List,
      * the message is prefixed with location details (Class, row/line number etc.) as well.
+     * <p>
      * {@inheritDoc}
      */
     public boolean handleMessage(final IMessage message) {

--- a/src/site/apt/ajc_reference/experimental_opts.apt
+++ b/src/site/apt/ajc_reference/experimental_opts.apt
@@ -12,24 +12,23 @@ AspectJ Compiler reference: non-standard options
   options of its goals, as defined in the {{{../plugin-info.html}Plugin Documentation}} page.
 
 +------------------------------------------
-AspectJ Compiler 1.8.2 non-standard options:
 
-	-XnoInline          dont inline advice
-	-XlazyTjp           create thisJoinPoint objects lazily
-	-Xreweavable        create class files that can be subsequently rewoven
-	                    by AspectJ. Deprecated, this is now on by default.
-	-Xreweavable:compress deprecated, reweavable is now default.
-	-XnotReweavable     create class files that cant be subsequently rewoven
-	                    by AspectJ.
-	-XserializableAspects allows aspects to implement serializable
-	-XterminateAfterCompilation compile classes then terminate before weaving
-	-XaddSerialVersionUID calculates and adds the serialVersionUID to any
-	                    serializable type woven by an aspect
-	-Xajruntimetarget:<level> allows code to be generated that targets
-	                    a 1.2 or a 1.5 level AspectJ runtime (default 1.5)
-	-XhasMember         allow hasmethod() and hasfield type patterns in
-	                    declare parents and declare @type
-	-Xjoinpoints:       supply a comma separated list of new joinpoints
-	                    that can be identified by pointcuts.  Values are:
-	                    arrayconstruction, synchronization
+AspectJ Compiler - Eclipse Compiler a00b62fa3572b0 (17Mar2021) - Java16
+
+ AspectJ-specific non-standard options:
+    -XnoInline            dont inline advice
+    -XnotReweavable       create class files that cant be subsequently rewoven
+                          by AspectJ.
+    -XserializableAspects allows aspects to implement serializable
+    -XterminateAfterCompilation compile classes then terminate before weaving
+    -XaddSerialVersionUID calculates and adds the serialVersionUID to any
+                          serializable type woven by an aspect
+    -Xajruntimetarget:<level> allows code to be generated that targets
+                          a 1.2, 1.5, 1.9 level AspectJ runtime (default 1.5)
+    -XhasMember           allow hasmethod() and hasfield type patterns in
+                          declare parents and declare @type
+    -Xjoinpoints:         supply a comma separated list of new joinpoints
+                          that can be identified by pointcuts. Values are:
+                          arrayconstruction, synchronization
+
 +------------------------------------------

--- a/src/site/apt/ajc_reference/standard_opts.apt
+++ b/src/site/apt/ajc_reference/standard_opts.apt
@@ -14,143 +14,216 @@ AspectJ Compiler reference: standard options
   For a reference of non-standard AJC options, please refer to {{{./experimental_opts.html}AJC Experimental Options}}.
 
 +------------------------------------------
-    AspectJ Compiler 1.8.2
 
-	    Usage: <options> <source file | @argfile>..
+AspectJ Compiler Eclipse Compiler a00b62fa3572b0 (17Mar2021) - Java16
 
-    AspectJ-specific options:
-	    -inpath <list>      use classes in dirs and jars/zips in <list> as source
-	                        (<list> uses platform-specific path delimiter)
-    	-injars <jarList>   use classes in <jarList> zip files as source
-    	                    (<jarList> uses classpath delimiter)
-    	                    deprecated - use inpath instead.
-        -aspectpath <list>  weave aspects in .class files from <list> dirs and jars/zip into sources
-                            (<list> uses classpath delimiter)
-        -outjar <file>      put output classes in zip file <file>
-	    -outxml             generate META-INF/aop.xml
-	    -outxmlfile <file>  specify alternate destination output of -outxml
-	    -argfile <file>     specify line-delimited list of source files
-	    -showWeaveInfo      display information about weaving
-	    -incremental        continuously-running compiler, needs -sourceroots
-    	                    (reads stdin: enter to recompile and 'q' to quit)
-    	-sourceroots <dirs> compile all .aj and .java files in <dirs>
-    	                    (<dirs> uses classpath delimiter)
-        -crossrefs          generate .ajsym file into the output directory
-        -parameters         stores formal parameter names of constructors and methods
-                            in the generated class file so that the method
-                            java.lang.reflect.Executable.getParameters from the Reflection API can retrieve them.
-        -emacssym           generate .ajesym symbol files for emacs support
-        -Xlint              same as '-Xlint:warning'
-        -Xlint:<level>      set default level for crosscutting messages
-                            (<level> may be ignore, warning, or error)
-        -Xlintfile <file>   specify properties file to set per-message levels
-                            (cf org/aspectj/weaver/XlintDefault.properties)
-        -X                  print help on non-standard options
+ Usage: <options> <source files | directories>
+ If directories are specified, then their source contents are compiled.
+ Possible options are listed below. Options enabled by default are prefixed
+ with '+'.
 
-    Standard Eclipse compiler options:
-    Options enabled by default are prefixed with '+'
+AspectJ-specific options:
+    -inpath <list>      use classes in dirs and jars/zips in <list> as source
+                        (<list> uses platform-specific path delimiter)
+    -injars <jarList>   use classes in <jarList> zip files as source
+                        (<jarList> uses classpath delimiter)
+                        deprecated - use inpath instead.
+    -aspectpath <list>  weave aspects in .class files from <list> dirs and jars/zip into sources
+                        (<list> uses classpath delimiter)
+    -outjar <file>      put output classes in zip file <file>
+    -outxml             generate META-INF/aop.xml
+    -outxmlfile <file>  specify alternate destination output of -outxml
+    -argfile <file>     specify line-delimited list of source files
+    -showWeaveInfo      display information about weaving
+    -incremental        continuously-running compiler, needs -sourceroots
+                        (reads stdin: enter to recompile and 'q' to quit)
+    -sourceroots <dirs> compile all .aj and .java files in <dirs>
+                        (<dirs> uses classpath delimiter)
+    -crossrefs          generate .ajsym file into the output directory
+    -emacssym           generate .ajesym symbol files for emacs support
+    -Xlint              same as '-Xlint:warning'
+    -Xlint:<level>      set default level for crosscutting messages
+                        (<level> may be ignore, warning, or error)
+    -Xlintfile <file>   specify properties file to set per-message levels
+                        (cf org/aspectj/weaver/XlintDefault.properties)
+    -X                  print help on non-standard options
 
-    Classpath options:
-        -cp -classpath <directories and zip/jar files separated by ;>
-                       specify location for application classes and sources
-        -bootclasspath <directories and zip/jar files separated by ;>
-                       specify location for system classes
-        -d <dir>           destination directory (if omitted, no directory is created)
-        -d none            generate no .class files
-        -encoding <enc>    specify custom encoding for all sources. Each file/directory can override it
-                           when suffixed with '['<enc>']' (e.g. X.java[utf8])
+ Standard Eclipse compiler options:
 
-    Compliance options:
-        -1.3               use 1.3 compliance level (implicit -source 1.3 -target 1.1)
-        -1.4             + use 1.4 compliance level
-        -1.5 -5 -5.0       use 1.5 compliance (-source 1.5 -target 1.5)
-        -1.6 -6 -6.0       use 1.6 compliance (-source 1.6 -target 1.6)
-        -1.7 -7 -7.0       use 1.7 compliance (-source 1.7 -target 1.7)
-        -1.8 -8 -8.0       use 1.8 compliance (-source 1.8 -target 1.8)
-        -source <version>  set source level: 1.3 to 1.8 (or 5, 5.0, etc)
-        -target <version>  set classfile target: 1.1 to 1.8 (or 5, 5.0, etc)
+ Classpath options:
+    -cp -classpath <directories and ZIP archives separated by ;>
+                       specify location for application classes and sources.
+                       Each directory or file can specify access rules for
+                       access to type X, [~X] to discourage access to type X,
+                       [+p/X;-p/*] to forbid access to all types in package p
+                       but allow access to p/X)
+    -bootclasspath <directories and ZIP archives separated by ;>
+                       specify location for system classes. Each directory or
+                       file can specify access rules for types between '['
+                       and ']'
+    -sourcepath <directories and ZIP archives separated by ;>
+                       specify location for application sources. Each directory
+                       or file can specify access rules for types between '['
+                       and ']'. Each directory can further specify a specific
+                       destination directory using a '-d' option between '['
+                       and ']'; this overrides the general '-d' option.
+                       .class files created from source files contained in a
+                       jar file are put in the user.dir folder in case no
+                       general '-d' option is specified. ZIP archives cannot
+                       override the general '-d' option
+    -extdirs <directories separated by ;>
+                       specify location for extension ZIP archives
+    -endorseddirs <directories separated by ;>
+                       specify location for endorsed ZIP archives
+    -d <dir>           destination directory (if omitted, no directory is
+                       created); this option can be overridden per source
+                       directory
+    -d none            generate no .class files
+    -encoding <enc>    specify default encoding for all source files. Each
+                       file/directory can override it when suffixed with
+                       '['<enc>']' (e.g. X.java[utf8]).
+                       If multiple default encodings are specified, the last
+                       one will be used.
 
-    Warning options:
-        -deprecation         + deprecation outside deprecated code
-        -nowarn -warn:none disable all warnings
-        -warn:<warnings separated by ,>    enable exactly the listed warnings
-        -warn:+<warnings separated by ,>   enable additional warnings
-        -warn:-<warnings separated by ,>   disable specific warnings
-            allDeadCode          dead code including trivial if(DEBUG) check
-            allDeprecation       deprecation including inside deprecated code
-            allJavadoc           invalid or missing javadoc
-            allOver-ann          all missing @Override annotations
-            all-static-method    all method can be declared as static warnings
-            assertIdentifier   + 'assert' used as identifier
-            boxing               autoboxing conversion
-            charConcat         + char[] in String concat
-            compareIdentical   + comparing identical expressions
-            conditionAssign      possible accidental boolean assignment
-            constructorName    + method with constructor name
-            deadCode           + dead code excluding trivial if (DEBUG) check
-            dep-ann              missing @Deprecated annotation
-            deprecation        + deprecation outside deprecated code
-            discouraged        + use of types matching a discouraged access rule
-            emptyBlock           undocumented empty block
-            enumIdentifier       'enum' used as identifier
-            enumSwitch           incomplete enum switch
-            fallthrough          possible fall-through case
-            fieldHiding          field hiding another variable
-            finalBound           type parameter with final bound
-            finally            + finally block not completing normally
-            forbidden          + use of types matching a forbidden access rule
-            hashCode              missing hashCode() method when overriding equals()
-            hiding               macro for fieldHiding, localHiding, typeHiding and
-                                 maskedCatchBlock
-            includeAssertNull    raise null warnings for variables
-                                 that got tainted in an assert expression
-            indirectStatic       indirect reference to static member
-            intfAnnotation     + annotation type used as super interface
-            intfNonInherited   + interface non-inherited method compatibility
-            intfRedundant        find redundant superinterfaces
-            javadoc              invalid javadoc
-            localHiding          local variable hiding another variable
-            maskedCatchBlock   + hidden catch block
-            nls                  string literal lacking non-nls tag //$NON-NLS-<n>$
-            noEffectAssign     + assignment without effect
-            null                 potential missing or redundant null check
-            nullDereference    + missing null check
-            over-ann             missing @Override annotation (superclass)
-            paramAssign          assignment to a parameter
-            pkgDefaultMethod   + attempt to override package-default method
-            raw                + usage of raw type
-            semicolon            unnecessary semicolon, empty statement
-            serial             + missing serialVersionUID
-            specialParamHiding   constructor or setter parameter hiding a field
-            static-method        method can be declared as static
-            static-access        macro for indirectStatic and staticReceiver
-            staticReceiver     + non-static reference to static member
-            super                overriding a method without making a super invocation
-            suppress           + enable @SuppressWarnings
-                                 When used with -err:, it can also silent optional
-                                 errors and warnings
-            syncOverride         missing synchronized in synchr. method override
-            syntheticAccess      synthetic access for innerclass
-            tasks(<tags separated by |>) tasks identified by tags inside comments
-            typeHiding         + type parameter hiding another type
-            unavoidableGenericProblems + ignore unavoidable type safety problems
-                                 due to raw APIs
-            unchecked          + unchecked type operation
-            unnecessaryElse      unnecessary else clause
-            unqualifiedField     unqualified reference to field
-            unused               macro for unusedAllocation, unusedArgument,
-                               unusedImport, unusedLabel, unusedLocal,
-                               unusedPrivate, unusedThrown, and unusedTypeArgs
-      unusedAllocation     allocating an object that is not used
-      unusedArgument       unread method parameter
-      unusedImport       + unused import declaration
-      unusedLabel        + unused label
-      unusedLocal        + unread local variable
-      unusedPrivate      + unused private member declaration
-      unusedThrown         unused declared thrown exception
-      unusedTypeArgs     + unused type arguments for method and constructor
-      uselessTypeCheck     unnecessary cast/instanceof operation
-      varargsCast        + varargs argument need explicit cast
-      warningToken       + unsupported or unnecessary @SuppressWarnings
+ Module compilation options:
+   These options are meaningful only in Java 9 environment or later.
+    --module-source-path <directories separated by ;>
+                       specify where to find source files for multiple modules
+    -p --module-path <directories separated by ;>
+                       specify where to find application modules
+    --processor-module-path <directories separated by ;>
+                       specify module path where annotation processors
+                       can be found
+    --system <jdk>     Override location of system modules
+    --add-exports <module>/<package>=<other-module>(,<other-module>)*
+                       specify additional package exports clauses to the
+                       given modules
+    --add-reads <module>=<other-module>(,<other-module>)*
+                       specify additional modules to be considered as required
+                       by given modules
+    --add-modules  <module>(,<module>)*
+                       specify the additional module names that should be
+                       resolved to be root modules
+    --limit-modules <module>(,<module>)*
+                       specify the observable module names
+    --release <release> compile for a specific VM version
+
+ Compliance options:
+    -1.3               use 1.3 compliance (-source 1.3 -target 1.1)
+    -1.4             + use 1.4 compliance (-source 1.3 -target 1.2)
+    -1.5 -5 -5.0       use 1.5 compliance (-source 1.5 -target 1.5)
+    -1.6 -6 -6.0       use 1.6 compliance (-source 1.6 -target 1.6)
+    -1.7 -7 -7.0       use 1.7 compliance (-source 1.7 -target 1.7)
+    -1.8 -8 -8.0       use 1.8 compliance (-source 1.8 -target 1.8)
+    -1.9 -9 -9.0       use 1.9 compliance (-source 1.9 -target 1.9)
+    -10 -10.0          use 10  compliance (-source 10  -target 10)
+    -11 -11.0          use 11  compliance (-source 11  -target 11)
+    -12 -12.0          use 12  compliance (-source 12  -target 12)
+    -13 -13.0          use 13  compliance (-source 13  -target 13)
+    -14 -14.0          use 14  compliance (-source 14  -target 14)
+    -15 -15.0          use 15  compliance (-source 15  -target 15)
+    -16 -16.0          use 16  compliance (-source 16  -target 16)
+    -source <version>  set source level: 1.3 to 1.9, 10 to 16
+                       (or 6, 6.0, etc)
+    -target <version>  set classfile target: 1.3 to 1.9, 10 to 16
+                       (or 6, 6.0, etc)
+                       cldc1.1 can also be used to generate the StackMap
+                       attribute
+    --enable-preview   enable support for preview features of the
+                       latest Java release
+
+ Warning options:
+    -deprecation     + deprecation outside deprecated code (equivalent to
+                       -warn:+deprecation)
+    -nowarn -warn:none disable all warnings
+    -nowarn:[<directories separated by ;>]
+                       specify directories from which optional problems should
+                       be ignored
+    -?:warn -help:warn display advanced warning options
+
+ Error options:
+    -err:<warnings separated by ,>    convert exactly the listed warnings
+                                      to be reported as errors
+    -err:+<warnings separated by ,>   enable additional warnings to be
+                                      reported as errors
+    -err:-<warnings separated by ,>   disable specific warnings to be
+                                      reported as errors
+
+ Info options:
+    -info:<warnings separated by ,>   convert exactly the listed warnings
+                                      to be reported as infos
+    -info:+<warnings separated by ,>  enable additional warnings to be
+                                      reported as infos
+    -info:-<warnings separated by ,>  disable specific warnings to be
+                                      reported as infos
+
+ Setting warning, error or info options using properties file:
+    -properties <file>   set warnings/errors/info option based on the properties
+                         file contents. This option can be used with -nowarn,
+                         -err:.., -info: or -warn:.. options, but the last one
+                         on the command line sets the options to be used.
+
+ Debug options:
+    -g[:lines,vars,source] custom debug info
+    -g:lines,source  + both lines table and source debug info
+    -g                 all debug info
+    -g:none            no debug info
+    -preserveAllLocals preserve unused local vars for debug purpose
+
+ Annotation processing options:
+   These options are meaningful only in a 1.6 environment.
+    -Akey[=value]        options that are passed to annotation processors
+    -processorpath <directories and ZIP archives separated by ;>
+                         specify locations where to find annotation processors.
+                         If this option is not used, the classpath will be
+                         searched for processors
+    -processor <class1[,class2,...]>
+                         qualified names of the annotation processors to run.
+                         This bypasses the default annotation discovery process
+    -proc:only           run annotation processors, but do not compile
+    -proc:none           perform compilation but do not run annotation
+                         processors
+    -s <dir>             destination directory for generated source files
+                         a processor is asked to process
+    -classNames <className1[,className2,...]>
+                         qualified names of binary classes to process
+
+ Advanced options:
+    @<file>            read command line arguments from file
+    -maxProblems <n>   max number of problems per compilation unit (100 by
+                       default)
+    -log <file>        log to a file. If the file extension is '.xml', then
+                       the log will be a xml file.
+    -proceedOnError[:Fatal]
+                       do not stop at first error, dumping class files with
+                       problem methods
+                       With ":Fatal", all optional errors are treated as fatal
+    -failOnWarning     fail compilation if there are warnings
+    -verbose           enable verbose output
+    -referenceInfo     compute reference info
+    -progress          show progress (only in -log mode)
+    -time              display speed information
+    -noExit            do not call System.exit(n) at end of compilation (n==0
+                       if no error)
+    -repeat <n>        repeat compilation process <n> times for perf analysis
+    -inlineJSR         inline JSR bytecode (implicit if target >= 1.5)
+    -enableJavadoc     consider references in javadoc
+    -parameters        generate method parameters attribute (for target >= 1.8)
+    -genericsignature  generate generic signature for lambda expressions
+                       It does not affect the xml log output
+    -missingNullDefault  report missing default nullness annotation
+    -annotationpath <directories and ZIP archives separated by ;>
+                       specify locations where to find external annotations
+                       to support annotation-based null analysis.
+                       The special name CLASSPATH will cause lookup of
+                       external annotations from the classpath and sourcepath.
+
+    -? -help           print this help message
+    -v -version        print compiler version
+    -showversion       print compiler version and continue
+
+ Ignored options:
+    -J<option>         pass option to virtual machine (ignored)
+    -O                 optimize for execution time (ignored)
 
 +------------------------------------------

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -2,8 +2,8 @@
          xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
   <body>
     <links>
-      <item name="AspectJ" href="http://aspectj.org"/>
-      <item name="AJC Documentation" href="http://www.eclipse.org/aspectj/doc/next/devguide/ajc-ref.html"/>
+      <item name="AspectJ" href="https://www.eclipse.org/aspectj/"/>
+      <item name="AJC Documentation" href="https://www.eclipse.org/aspectj/doc/released/devguide/ajc-ref.html"/>
     </links>
     <menu name="Overview">
       <item name="Introduction" href="./index.html"/>

--- a/src/test/java/org/codehaus/mojo/aspectj/AbstractAjcCompilerTest.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/AbstractAjcCompilerTest.java
@@ -48,6 +48,7 @@ public class AbstractAjcCompilerTest
     /** Compiler mojo instance */
     private AjcTestCompileMojo ajcCompMojo;
 
+    @Override
     protected void setUp()
         throws Exception
     {
@@ -63,11 +64,10 @@ public class AbstractAjcCompilerTest
     /**
      * Verifies that if not stated no -inpath argument should be found in the ajc arguments
      * {@link AbstractAjcCompiler#execute()}
-     * 
-     * @throws Exception
+     *
+     * @throws MojoExecutionException if the mojo fails to execute
      */
-    public void testGetAjcArguments_noWeaveArtifacts()
-        throws Exception
+    public void testGetAjcArguments_noWeaveArtifacts() throws MojoExecutionException
     {
         ajcCompMojo.assembleArguments();
         List args = ajcCompMojo.ajcOptions;
@@ -76,11 +76,8 @@ public class AbstractAjcCompilerTest
 
     /**
      * Tests that the compiler fails as it should if told to weave an artifact not listed in the project dependencies.
-     * 
-     * @throws Exception
      */
     public void testGetAjcArguments_weaveArtifactsNotProjectDependecy()
-        throws Exception
     {
         Module module1 = new Module();
         String mod1Group = "dill.group";
@@ -103,11 +100,10 @@ public class AbstractAjcCompilerTest
     /**
      * Tests if modules told to weave that are found in the project dependencies actually are found in the .inpath ajc
      * argument,.
-     * 
-     * @throws Exception
+     *
+     * @throws MojoExecutionException if the mojo fails to execute
      */
-    public void testGetAjcArguments_weaveArtifacts()
-        throws Exception
+    public void testGetAjcArguments_weaveArtifacts() throws MojoExecutionException
     {
         ajcCompMojo.weaveDependencies = new Module[2];
         Module module1 = new Module();
@@ -144,11 +140,10 @@ public class AbstractAjcCompilerTest
     /**
      * Tests if modules told to weave that are found in the project dependencies actually are found in the .inpath ajc
      * argument, considering classifiers.
-     * 
-     * @throws Exception
+     *
+     * @throws MojoExecutionException if the mojo fails to execute
      */
-    public void testGetAjcArguments_weaveArtifactsWithClassifier()
-        throws Exception
+    public void testGetAjcArguments_weaveArtifactsWithClassifier() throws MojoExecutionException
     {
         ajcCompMojo.weaveDependencies = new Module[1];
         Module module1 = new Module();
@@ -182,11 +177,10 @@ public class AbstractAjcCompilerTest
     /**
      * Tests if modules told to weave that are found in the project dependencies actually are found in the .inpath ajc
      * argument, considering type.
-     * 
-     * @throws Exception
+     *
+     * @throws MojoExecutionException if the mojo fails to execute
      */
-    public void testGetAjcArguments_weaveArtifactsWithType()
-        throws Exception
+    public void testGetAjcArguments_weaveArtifactsWithType() throws MojoExecutionException
     {
         ajcCompMojo.weaveDependencies = new Module[1];
         Module module1 = new Module();
@@ -219,8 +213,8 @@ public class AbstractAjcCompilerTest
 
     /**
      * Tests if modules told to weave classes that are found in directories.
-     * 
-     * @throws Exception
+     *
+     * @throws Exception on test error
      */
     public void testGetAjcArguments_weaveDirectories()
         throws Exception
@@ -246,8 +240,8 @@ public class AbstractAjcCompilerTest
      * Verifies that if not stated no -aspectpath argument should
      * be found in the ajc arguments
      * {@link AbstractAjcCompiler#execute()}
-     * 
-     * @throws Exception
+     *
+     * @throws Exception on test error
      */
     public void testGetAjcArguments_noLibraryArtifacts()
         throws Exception
@@ -260,9 +254,8 @@ public class AbstractAjcCompilerTest
     /**
      * Tests that the compiler fails as it should if told to weave an library artifact not listed in the project
      * dependencies.
-     * 
      */
-    public void testGetAjcArguments_libraryArtifactsNotProjectDependecy()
+    public void testGetAjcArguments_libraryArtifactsNotProjectDependency()
     {
         Module module1 = new Module();
         String mod1Group = "dill.group";
@@ -285,8 +278,8 @@ public class AbstractAjcCompilerTest
     /**
      * Tests if modules told to weave that are found in the project dependencies actually are found in the .inpath ajc
      * argument,.
-     * 
-     * @throws Exception
+     *
+     * @throws Exception on test error
      */
     public void testGetAjc_libraryArtifacts()
         throws Exception

--- a/src/test/java/org/codehaus/mojo/aspectj/AjcCompilerMojoTest.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/AjcCompilerMojoTest.java
@@ -48,7 +48,7 @@ public class AjcCompilerMojoTest
     }
 
     /**
-     * @throws Exception
+     * @throws Exception on test error
      */
     public void testModificationSet()
         throws Exception
@@ -80,7 +80,7 @@ public class AjcCompilerMojoTest
             ajcMojo.ajcOptions.clear();
             ajcMojo.includes = includes;
             ajcMojo.assembleArguments();
-            assertFalse("A build has compleeted. No modifications done. no new build needed",ajcMojo.isBuildNeeded());
+            assertFalse("A build has completed. No modifications done. no new build needed",ajcMojo.isBuildNeeded());
 
             ajcMojo.ajcOptions.clear();
             ajcMojo.includes = includes;
@@ -92,7 +92,7 @@ public class AjcCompilerMojoTest
             ajcMojo.ajcOptions.clear();
             ajcMojo.includes = includes;
             ajcMojo.assembleArguments();
-            assertFalse("A build has compleeted. No modifications done. no new build needed",ajcMojo.isBuildNeeded());
+            assertFalse("A build has completed. No modifications done. no new build needed",ajcMojo.isBuildNeeded());
             String currentDir = new File(".").getAbsolutePath();
             File aspect = new File(currentDir.substring(0,currentDir.length()-1)+"src/test/projects/test-project/src/main/aspect/org/codehaus/mojo/aspectj/OldStyleAspect.aj");
             long timeStamp = System.currentTimeMillis();

--- a/src/test/java/org/codehaus/mojo/aspectj/AjcHelperTest.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/AjcHelperTest.java
@@ -43,14 +43,15 @@ import org.codehaus.plexus.util.FileUtils;
 public class AjcHelperTest
     extends TestCase
 {
-
     public void testGetAsCsv()
-        throws Exception
     {
         String[] tests = new String[] { "kaare", "java", "aspectJ" };
         assertEquals( "kaare,java,aspectJ", AjcHelper.getAsCsv( tests ) );
     }
 
+    /**
+     * @throws Exception on test error
+     */
     public void testGetSourcesEmptyBaseDir()
         throws Exception
     {

--- a/src/test/java/org/codehaus/mojo/aspectj/MockArtifact.java
+++ b/src/test/java/org/codehaus/mojo/aspectj/MockArtifact.java
@@ -59,8 +59,8 @@ public class MockArtifact
     /**
      * Constructor
      * 
-     * @param groupId
-     * @param artifactId
+     * @param groupId group ID
+     * @param artifactId artifact ID
      */
     public MockArtifact( String groupId, String artifactId )
     {
@@ -69,12 +69,12 @@ public class MockArtifact
     }
 
     /**
-     * Construstor with type and classifier
-     * 
-     * @param groupId
-     * @param artifactId
-     * @param classifier
-     * @param type
+     * Constructor with type and classifier
+     *
+     * @param groupId group ID
+     * @param artifactId artifact ID
+     * @param classifier artifact classifier
+     * @param type artifact type
      */
     public MockArtifact( String groupId, String artifactId, String classifier, String type )
     {
@@ -326,7 +326,7 @@ public class MockArtifact
     /**
      * Very simple compareTo implementation
      *
-     * @param a
+     * @param a other artifact to compare to
      * @return compare value
      */
     public int compareTo( Artifact a )


### PR DESCRIPTION
They correspond to AJC/ECJ/Javac parameters `--enable-preview` and `--module-path`.

Also contained: ECJ (thus also AJC) accepts source/target like `5.0`..`16.0`. So these are in the list of allowed version numbers now
(`AjcHelper.ACCEPTED_COMPLIANCE_LEVEL_VALUES`).

Please note that this PR is branched off of #99. I.e. if you merge it afterwards, there will be no merge conflicts. If you prefer me to rather cherry-pick on master, I can do that too. But then maybe you have to merge, I did not check.

In addition to the 3 trivial PRs I 98-100, I also would like to contribute a few build-related things, but these require discussion first, so I want to wait for these 3 to be merged first, then we have a clean point to start from instead of juggling too many balls at once.