### PR TITLE
Extract resolved includes logic into a method for input tracking

### DIFF
--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -645,15 +645,19 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
         ajcOptions.add(getGeneratedSourcesDirectory().getAbsolutePath());
 
         // Add all the files to be included in the build,
-        if (null != ajdtBuildDefFile) {
-            resolvedIncludes = AjcHelper.getBuildFilesForAjdtFile(ajdtBuildDefFile, basedir);
-        } else {
-            resolvedIncludes = getIncludedSources();
-        }
+        resolvedIncludes = getResolvedIncludes();
         ajcOptions.addAll(resolvedIncludes);
 
         if (CollectionUtils.isNotEmpty(additionalCompilerArgs)) {
             ajcOptions.addAll(additionalCompilerArgs);
+        }
+    }
+
+    private Set<String> getResolvedIncludes() throws MojoExecutionException {
+        if (null != ajdtBuildDefFile) {
+            return AjcHelper.getBuildFilesForAjdtFile(ajdtBuildDefFile, basedir);
+        } else {
+            return getIncludedSources();
         }
     }
 


### PR DESCRIPTION
Extracting resolved includes into a method will allow this plugin to properly work with the [Gradle Enterprise Maven extension](https://docs.gradle.com/enterprise/maven-extension/).