### PR TITLE
An option with an ambiguous meaning caused Lombok weaving to fail.

### DIFF
--- a/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
+++ b/src/main/java/org/codehaus/mojo/aspectj/AbstractAjcCompiler.java
@@ -663,13 +663,14 @@ public abstract class AbstractAjcCompiler extends AbstractAjcMojo {
         ajcOptions.add("-s");
         ajcOptions.add(getGeneratedSourcesDirectory().getAbsolutePath());
 
+        // Add all the files to be included in the build,
+        if (null != ajdtBuildDefFile) {
+            resolvedIncludes = AjcHelper.getBuildFilesForAjdtFile(ajdtBuildDefFile, basedir);
+        } else {
+            resolvedIncludes = getIncludedSources();
+        }
+
         if (containsResolvedIncludes) {
-            // Add all the files to be included in the build,
-            if (null != ajdtBuildDefFile) {
-                resolvedIncludes = AjcHelper.getBuildFilesForAjdtFile(ajdtBuildDefFile, basedir);
-            } else {
-                resolvedIncludes = getIncludedSources();
-            }
             ajcOptions.addAll(resolvedIncludes);
         }
 


### PR DESCRIPTION
Fixes #231 