### PR TITLE
Publish test results through the shared workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -65,6 +65,26 @@ jobs:
         shell: bash
         run: mvn --show-version --errors --batch-mode "-Dinvoker.streamLogsOnFailures=true" "-Prun-its,docs" clean verify
 
+      - name: Upload test results
+        uses: actions/upload-artifact@v6
+        if: always()
+        with:
+          name: Test Results
+          path: |
+            **/target/surefire-reports/TEST*.xml
+            **/target/failsafe-reports/TEST*.xml
+
+
+  event_file:
+    name: Publish event file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload
+        uses: actions/upload-artifact@v6
+        with:
+          name: Event File
+          path: ${{ github.event_path }}
+
   site:
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/tests-result.yml
+++ b/.github/workflows/tests-result.yml
@@ -1,0 +1,17 @@
+name: Reports
+
+on:
+  workflow_run:
+    workflows: ["GitHub CI"]
+    types:
+      - completed
+
+permissions: {}
+
+jobs:
+  test-results:
+    permissions:
+      checks: write
+      pull-requests: write
+      actions: read
+    uses: mojohaus/.github/.github/workflows/test-results.yml@master


### PR DESCRIPTION
Wires this repo into the shared test-results workflow added in mojohaus/.github#3, so JUnit results land as a check run and, on pull requests, as a comment. buildplan-maven-plugin has been running it since yesterday.

Two pieces: `maven.yml` uploads the surefire and failsafe XML plus the event payload, and a `Reports` workflow feeds them to the shared workflow from a `workflow_run` trigger, so pull requests from forks get their results published without the build itself holding write permissions.

The action version and the permission set live once in `mojohaus/.github`, not here.

*This change was created with AI assistance.*
